### PR TITLE
Removing extra space in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Bug Description
       description: >
-         If applicable, add screenshots to 
+        If applicable, add screenshots to 
         help explain the problem you are facing.      
     validations:
       required: true


### PR DESCRIPTION
Fixing a previous template change that added an extra space that failed parsing.