### PR TITLE
Fix ingress path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,6 @@ unit:
 		-v \
 		-s \
 		$(ARGS)
-	uv run --all-extras \
-		coverage run \
-		--source=$(SRC) \
-		--append \
-		-m pytest \
-		--tb native \
-		--verbose \
-		--capture=no \
-		$(TESTS)/scenario \
-		$(ARGS)
 	uv run --all-extras coverage report
 
 integration:

--- a/lib/charms/parca_k8s/v0/parca_config.py
+++ b/lib/charms/parca_k8s/v0/parca_config.py
@@ -21,6 +21,8 @@ yaml_config = str(ParcaConfig())
 cmd = parca_command_line(app_config)
 ```
 """
+from typing import Optional
+
 import yaml
 
 # The unique Charmhub library identifier, never change it
@@ -31,7 +33,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 DEFAULT_BIN_PATH = "/parca"
@@ -45,6 +47,7 @@ def parca_command_line(
     bin_path: str = DEFAULT_BIN_PATH,
     config_path: str = DEFAULT_CONFIG_PATH,
     profile_path: str = DEFAULT_PROFILE_PATH,
+    path_prefix: Optional[str] = None,
     store_config: dict = None,
 ) -> str:
     """Generate a valid Parca command line.
@@ -54,9 +57,20 @@ def parca_command_line(
         bin_path: Path to the Parca binary to be started.
         config_path: Path to the Parca YAML configuration file.
         profile_path: Path to profile storage directory.
+        path_prefix: Path prefix to configure parca server with.
         store_config: Configuration to send profiles to a remote store
     """
-    cmd = [str(bin_path), f"--config-path={config_path}"]
+    cmd = [str(bin_path),
+           f"--config-path={config_path}",
+           ]
+
+    if path_prefix:
+        if not path_prefix.startswith("/"):
+            # parca will blow up if you try this
+            raise ValueError("invalid path_prefix: should start with a slash.")
+        # quote path_prefix so we don't have to escape the slashes
+        path_prefix_option = f"--path-prefix='{path_prefix}'"
+        cmd.append(path_prefix_option)
 
     # Render the template files with the correct values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "tenacity",
     "sh",
     "pyright",
+    "ops[testing]"
 ]
 
 [tool.coverage.run]

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,8 @@
 """Charmed Operator to deploy Parca - a continuous profiling tool."""
 
 import logging
+from typing import Optional
+from urllib.parse import urlparse
 
 import ops
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
@@ -76,13 +78,24 @@ class ParcaOperatorCharm(ops.CharmBase):
         """Handle the update status hook on an interval dictated by model config."""
         self.unit.set_workload_version(self.parca.version)
 
+    @property
+    def _external_url_path(self)->Optional[str]:
+        """The path part of our external url if we are ingressed, else None.
+
+        This is used to configure the parca server so it can resolve its internal links.
+        """
+        if not self.ingress.is_ready():
+            return None
+        external_url = urlparse(self.ingress.url)
+        return external_url.path or None
+
     def _configure_and_start(self, event):
         """Start Parca having (re)configured it with the relevant jobs."""
         self.unit.status = ops.MaintenanceStatus("reconfiguring parca")
 
         if self.container.can_connect():
             # Grab the scrape configs and push a generated config file into the container
-            # Parca will automatically reload it's config on changes
+            # Parca will automatically reload its config on changes
             config = self.parca.generate_config(self.profiling_consumer.jobs())
             self.container.push(CONFIG_PATH, str(config), make_dirs=True, permissions=0o644)
 
@@ -91,7 +104,8 @@ class ParcaOperatorCharm(ops.CharmBase):
 
             # Add an updated Pebble layer to the container
             # Add a config hash to the layer so if the config changes, replan restarts the service
-            layer = self.parca.pebble_layer(self.config, store_conf)
+            layer = self.parca.pebble_layer(self.config, store_conf,
+                                            path_prefix=self._external_url_path)
             self.container.add_layer("parca", layer, combine=True)
             self.container.replan()
 

--- a/src/parca.py
+++ b/src/parca.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 import urllib.request
+from typing import Optional
 
 from charms.parca_k8s.v0.parca_config import ParcaConfig, parca_command_line
 from ops.pebble import Layer
@@ -26,7 +27,7 @@ class Parca:
     # Seconds to wait in between requests to version endpoint
     _version_retry_wait = 3
 
-    def pebble_layer(self, config, store_config={}) -> Layer:
+    def pebble_layer(self, config, store_config=None, path_prefix:Optional[str]=None) -> Layer:
         """Return a Pebble layer for Parca based on the current configuration."""
         return Layer(
             {
@@ -35,7 +36,9 @@ class Parca:
                         "override": "replace",
                         "summary": "parca",
                         "command": parca_command_line(
-                            app_config=config, store_config=store_config
+                            app_config=config,
+                            store_config=store_config or {},
+                            path_prefix=path_prefix
                         ),
                         "startup": "enabled",
                     }

--- a/src/parca.py
+++ b/src/parca.py
@@ -27,7 +27,7 @@ class Parca:
     # Seconds to wait in between requests to version endpoint
     _version_retry_wait = 3
 
-    def pebble_layer(self, config, store_config=None, path_prefix:Optional[str]=None) -> Layer:
+    def pebble_layer(self, config, store_config=None, path_prefix: Optional[str] = None) -> Layer:
         """Return a Pebble layer for Parca based on the current configuration."""
         return Layer(
             {
@@ -38,7 +38,7 @@ class Parca:
                         "command": parca_command_line(
                             app_config=config,
                             store_config=store_config or {},
-                            path_prefix=path_prefix
+                            path_prefix=path_prefix,
                         ),
                         "startup": "enabled",
                     }

--- a/tests/scenario/test_empty.py
+++ b/tests/scenario/test_empty.py
@@ -1,3 +1,2 @@
 def test_empty():
-    """Placeholder until tests are added."""
     pass

--- a/tests/unit/test_parca_ingress.py
+++ b/tests/unit/test_parca_ingress.py
@@ -1,0 +1,108 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from charms.parca_k8s.v0.parca_config import parca_command_line
+from ops.pebble import Layer
+from ops.testing import Container, Context, Relation, State
+
+from charm import ParcaOperatorCharm
+
+DEFAULT_CONFIG = {"enable-persistence": False, "memory-storage-limit": 1024}
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_version():
+    with patch("parca.Parca._fetch_version", lambda _: "0.0.42"):
+        yield
+
+
+@pytest.mark.parametrize("path", ("fubar", "livingbeef"))
+def test_prefix_ingress_pebble_ready(path):
+    # GIVEN a parca charm with an ingress relation
+    ctx = Context(ParcaOperatorCharm)
+
+    container = Container("parca", can_connect=True)
+    state = State(
+        containers={container},
+        relations={
+            Relation(
+                "ingress",
+                remote_app_data={"ingress": json.dumps({"url": f"http://example.com/{path}"})},
+            )
+        },
+    )
+
+    # WHEN we process a pebble-ready
+    state_out = ctx.run(ctx.on.pebble_ready(container), state)
+
+    # THEN the plan's command contains a path-prefix arg
+    command = state_out.get_container("parca").plan.services["parca"].command.split()
+    assert f"--path-prefix='/{path}'" in command
+
+
+@pytest.mark.parametrize("path", ("fubar", None))
+def test_no_prefix_ingress_broken(path):
+    # GIVEN a parca charm without an ingress relation,
+    #   regardless of the prefix previously in the command
+    ctx = Context(ParcaOperatorCharm)
+    container = Container(
+        "parca",
+        can_connect=True,
+        layers={
+            "parca": Layer(
+                {
+                    "override": "replace",
+                    "summary": "parca",
+                    "command": parca_command_line(DEFAULT_CONFIG, path_prefix=None),
+                    "startup": "enabled",
+                }
+            )
+        },
+    )
+
+    ingress = Relation("ingress")
+    state = State(relations={ingress}, containers={container})
+
+    # WHEN we process a relation-broken
+    state_out = ctx.run(ctx.on.relation_broken(ingress), state)
+
+    # THEN the plan's command is updated to contain no path-prefix arg
+    command = state_out.get_container("parca").plan.services["parca"].command
+    assert "--path-prefix" not in command
+
+
+@pytest.mark.parametrize("path", ("fubar", None))
+@pytest.mark.parametrize("new_path", ("baaz", "quzzified"))
+def test_prefix_ingress_created(path, new_path):
+    # GIVEN a parca charm with an ingress relation,
+    #   regardless of the prefix previously in the command
+    ctx = Context(ParcaOperatorCharm)
+
+    container = Container(
+        "parca",
+        can_connect=True,
+        layers={
+            "parca": Layer(
+                {
+                    "override": "replace",
+                    "summary": "parca",
+                    "command": parca_command_line(DEFAULT_CONFIG, path_prefix=None),
+                    "startup": "enabled",
+                }
+            )
+        },
+    )
+
+    ingress = Relation(
+        "ingress",
+        remote_app_data={"ingress": json.dumps({"url": f"http://example.com/{new_path}"})},
+    )
+    state = State(relations={ingress}, containers={container})
+
+    # WHEN we process a relation-broken
+    state_out = ctx.run(ctx.on.relation_created(ingress), state)
+
+    # THEN the plan's command is updated to contain the right path-prefix arg
+    command = state_out.get_container("parca").plan.services["parca"].command
+    assert f"--path-prefix='/{new_path}'" in command

--- a/uv.lock
+++ b/uv.lock
@@ -752,6 +752,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/3f9884051be5df318e3f1d9e67737295b34d045a135147de8a49afa88f9b/ops-2.17.1-py3-none-any.whl", hash = "sha256:0fabc45740d59619c3265328f51f71f99b06557e22493cdd32d10c2b25bcd553", size = 176831 },
 ]
 
+[package.optional-dependencies]
+testing = [
+    { name = "ops-scenario" },
+]
+
+[[package]]
+name = "ops-scenario"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ee/59323da3ea693f6e1001f30c600dcd5cdb7703c5b79a684c3379327bf8f9/ops_scenario-7.0.5.tar.gz", hash = "sha256:7ef7af6d026a29f93d54f394f6757170317a85cbfa755dab1303b94610a29b82", size = 260175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/94/aa9b6f5cce795583820c4bbffa50df5c4245095b92e075930f4cb42b0021/ops_scenario-7.0.5-py3-none-any.whl", hash = "sha256:9f06c1989a62181e4952cbfe2002cbaa1290dc1d203245a6b1ce2f96e132615b", size = 74106 },
+]
+
 [[package]]
 name = "packaging"
 version = "24.2"
@@ -793,6 +811,7 @@ dev = [
     { name = "cosl" },
     { name = "coverage", extra = ["toml"] },
     { name = "juju" },
+    { name = "ops", extra = ["testing"] },
     { name = "pydantic" },
     { name = "pyright" },
     { name = "pytest" },
@@ -812,6 +831,7 @@ requires-dist = [
     { name = "lightkube" },
     { name = "lightkube-models" },
     { name = "ops" },
+    { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
     { name = "pydantic", specifier = "<3" },
     { name = "pydantic", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },


### PR DESCRIPTION
there is an issue with the ingress path: 
- if parca is related to ingress, the ingressed UI URL will give a broken page as the resources can't be loaded
- the parca unit URL will give a working UI


the issue is that we need to configure the parca server with a url prefix argument to adjust the links as parca is being served under  a subpath.

To test:

```
juju deploy cos-lite
juju deploy parca-k8s
jhack imatrix fill
```

now the UI at parca's URL will be broken (but that's ok)
but the ingressed URL will give you a working UI.
