### PR TITLE
Update oci-image to v0.22.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -36,7 +36,7 @@ resources:
     type: oci-image
     description: OCI image for parca
     # Included for simplicity in integration tests
-    upstream-source: ghcr.io/parca-dev/parca:main-1702262300-7cde99c3
+    upstream-source: ghcr.io/parca-dev/parca:v0.22.0
 
 storage:
   profiles:


### PR DESCRIPTION
Fixes https://github.com/canonical/parca-agent-operator/issues/42

`parca-k8s` was using a very old version that is not compatible with the newer versions of `parca-agent`.
Starting from `parca-agent` v0.32.0, we need a minimum version of `0.22.0` for `parca-k8s`.

## Context
https://github.com/parca-dev/parca-agent/releases/tag/v0.32.0

## Testing Instructions
In K8s model:
```
juju deploy ./parca-k8s_amd64.charm parca --resource parca-image=ghcr.io/parca-dev/parca:v0.22.0
juju offer parca:parca-store-endpoint 
```
In a machine model:
```
juju deploy ubuntu --channel edge --base ubuntu@24.04
juju deploy parca-agent  --channel edge
juju integrate parca-agent ubuntu
juju consume micro:test.parca
juju integrate parca-agent parca
```
Then, login to parca UI at <parca_k8s_IP>:7070, you should see the system-wide profiling data.