### PR TITLE
Add 22.04 base so that new revisions are available

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,9 +7,9 @@ description: |
   time. Saving infrastructure cost, improving performance, and increasing reliability.
 
 type: "charm"
-base: ubuntu@24.04
 platforms:
-  amd64:
+  ubuntu@24.04:amd64:
+  ubuntu@22.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
New revisions of parca weren't available to anyone trying to deploy it with juju without a `--base ubuntu@24.04` argument on ubuntu 22.04.


## Solution
<!-- A summary of the solution addressing the above issue -->
Pack a charm also for 22.04. Fixes #394 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
