### PR TITLE
List endpoints action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -132,6 +132,12 @@ peers:
   parca-peers:
     interface: parca_peers
 
+actions:
+  list-endpoints:
+    description: | 
+      Return the ingestion endpoints that the parca server is listening on for grpc and http profiling data.
+      Will list both direct and ingressed hosts.
+
 config:
   options:
     enable-persistence:

--- a/src/charm.py
+++ b/src/charm.py
@@ -185,6 +185,7 @@ class ParcaOperatorCharm(ops.CharmBase):
 
         # event handlers
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+        self.framework.observe(self.on.list_endpoints_action, self._on_list_endpoints_action)
         # unconditional logic
         self.reconcile()
 
@@ -389,6 +390,11 @@ class ParcaOperatorCharm(ops.CharmBase):
             self.unit.set_workload_version(self.parca.version)
 
         event.add_status(ops.ActiveStatus(f"UI ready at {self.http_server_url}"))
+
+    def _on_list_endpoints_action(self, event: ops.ActionEvent):
+        """React to the list-endpoints action."""
+
+
 
 
 def _generic_scrape_target(

--- a/src/charm.py
+++ b/src/charm.py
@@ -398,13 +398,10 @@ class ParcaOperatorCharm(ops.CharmBase):
             "direct-grpc-url": f"{self._fqdn}:{Nginx.parca_grpc_server_port}"
         }
 
-        if external_host := self.ingress.http_external_host:
-            out.update(
-                {
-                    "ingressed-http-url": f"{external_host}:{Nginx.parca_http_server_port}",
-                    "ingressed-grpc-url": f"{external_host}:{Nginx.parca_grpc_server_port}",
-                }
-            )
+        if http_external_host := self.ingress.http_external_host:
+            out["ingressed-http-url"]= f"{http_external_host}:{Nginx.parca_http_server_port}"
+        if grpc_external_host := self.ingress.grpc_external_host:
+            out["ingressed-grpc-url"]= f"{grpc_external_host}:{Nginx.parca_grpc_server_port}"
         event.set_results(out)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -393,8 +393,19 @@ class ParcaOperatorCharm(ops.CharmBase):
 
     def _on_list_endpoints_action(self, event: ops.ActionEvent):
         """React to the list-endpoints action."""
+        out = {
+            "direct-http-url": f"{self._scheme}://{self._fqdn}:{Nginx.parca_http_server_port}",
+            "direct-grpc-url": f"{self._fqdn}:{Nginx.parca_grpc_server_port}"
+        }
 
-
+        if external_host := self.ingress.http_external_host:
+            out.update(
+                {
+                    "ingressed-http-url": f"{external_host}:{Nginx.parca_http_server_port}",
+                    "ingressed-grpc-url": f"{external_host}:{Nginx.parca_grpc_server_port}",
+                }
+            )
+        event.set_results(out)
 
 
 def _generic_scrape_target(

--- a/tests/unit/test_charm/conftest.py
+++ b/tests/unit/test_charm/conftest.py
@@ -10,8 +10,8 @@ from charm import ParcaOperatorCharm
 @pytest.fixture(autouse=True)
 def patch_buffer_file_for_charm_tracing(tmp_path):
     with patch(
-        "charms.tempo_coordinator_k8s.v0.charm_tracing.BUFFER_DEFAULT_CACHE_FILE_NAME",
-        str(tmp_path / "foo.json"),
+            "charms.tempo_coordinator_k8s.v0.charm_tracing.BUFFER_DEFAULT_CACHE_FILE_NAME",
+            str(tmp_path / "foo.json"),
     ):
         yield
 

--- a/tests/unit/test_charm/test_charm.py
+++ b/tests/unit/test_charm/test_charm.py
@@ -429,14 +429,14 @@ def test_list_endpoints_action(context, base_state, tls, ingress):
     fqdn = socket.getfqdn()
 
     expected_results = {
+        'direct-http-url': f'{scheme}://{fqdn}:{Nginx.parca_http_server_port}',
         'direct-grpc-url': f'{fqdn}:{Nginx.parca_grpc_server_port}',
-        'direct-http-url': f'{scheme}://{fqdn}:{Nginx.parca_http_server_port}'
     }
     if ingress:
         expected_results.update(
             {
                 "ingressed-http-url": f"{scheme}://{external_host}:{Nginx.parca_http_server_port}",
-                "ingressed-grpc-url": f"{scheme}://{external_host}:{Nginx.parca_grpc_server_port}",
+                "ingressed-grpc-url": f"{external_host}:{Nginx.parca_grpc_server_port}",
             }
         )
     assert results == expected_results


### PR DESCRIPTION
Fixes #420 

Action output will differ if you have ingress

![image](https://github.com/user-attachments/assets/c60b2e04-880e-44d9-9754-3cfd4a536ecd)

To test:

```commandline
juju deploy cos-lite --channel edge --trust
juju deploy ./parca-k8s_ubuntu@22.04-amd64.charm parca
juju run parca/0 list-endpoints
juju relate parca traefik
juju run parca/0 list-endpoints
```