### PR TITLE
Send Parca traces over TLS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -385,13 +385,6 @@ class ParcaOperatorCharm(ops.CharmBase):
     def _workload_tracing_endpoint(self) -> Optional[str]:
         if self.workload_tracing.is_ready():
             endpoint = self.workload_tracing.get_endpoint("otlp_grpc")
-            # TODO: Parca fails to send traces over TLS.
-            # https://github.com/canonical/parca-k8s-operator/issues/405
-            if endpoint and self._tls_ready:
-                logger.warning(
-                    "Sending workload traces over TLS is not yet supported. Disable TLS to continue sending workload traces."
-                )
-                return None
             return endpoint
         return None
 

--- a/src/parca.py
+++ b/src/parca.py
@@ -140,7 +140,7 @@ class Parca:
                             enable_persistence=bool(self._enable_persistence or self._s3_config),
                             store_config=self._store_config,
                             tracing_endpoint=self._tracing_endpoint,
-                            tracing_tls=self._tls_config,
+                            tracing_tls=bool(self._tls_config),
                         ),
                         "startup": "enabled",
                         "environment": env,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -132,7 +132,8 @@ async def test_grafana_dashboard_relation(ops_test: OpsTest):
     )
 
 
-# FIXME: uncomment test once https://github.com/canonical/parca-k8s-operator/issues/403 is fixed
+# FIXME: We need to perform a profiles query on Parca to stimulate it to generate traces
+# https://github.com/canonical/parca-k8s-operator/issues/403
 # async def test_workload_tracing_relation(ops_test: OpsTest):
 #     await deploy_tempo_cluster(ops_test)
 #     await asyncio.gather(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -86,9 +86,8 @@ async def test_profiling_scraping(ops_test):
     assert PARCA_TESTER in output
 
 
-# FIXME: uncomment test once
+# FIXME: We need to perform a profiles query on Parca to stimulate it to generate traces
 # https://github.com/canonical/parca-k8s-operator/issues/403
-# and https://github.com/canonical/parca-k8s-operator/issues/405 are fixed.
 # async def test_workload_tracing(ops_test: OpsTest):
 #     await deploy_tempo_cluster(ops_test)
 #     await asyncio.gather(

--- a/tests/unit/test_charm/conftest.py
+++ b/tests/unit/test_charm/conftest.py
@@ -1,8 +1,9 @@
+import json
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ops.testing import Container, Context, PeerRelation
+from ops.testing import Container, Context, PeerRelation, Relation
 
 from charm import ParcaOperatorCharm
 
@@ -66,4 +67,16 @@ def nginx_prometheus_exporter_container():
     return Container(
         "nginx-prometheus-exporter",
         can_connect=True,
+    )
+
+
+@pytest.fixture
+def workload_tracing_relation():
+    remote_app_databag = {
+        "receivers": json.dumps(
+            [{"protocol": {"name": "otlp_grpc", "type": "grpc"}, "url": "192.0.2.0/24"}]
+        )
+    }
+    return Relation(
+        "workload-tracing", remote_app_name="backend", remote_app_data=remote_app_databag
     )

--- a/tests/unit/test_charm/test_tls.py
+++ b/tests/unit/test_charm/test_tls.py
@@ -78,6 +78,7 @@ def base_state(
     nginx_prometheus_exporter_container,
     certificates,
     private_key,
+    workload_tracing_relation,
 ):
     private_key_secret = Secret(
         {"private-key": private_key.raw},
@@ -86,7 +87,7 @@ def base_state(
     )
     return State(
         leader=True,
-        relations=[certificates],
+        relations=[certificates, workload_tracing_relation],
         containers=[parca_container, nginx_container, nginx_prometheus_exporter_container],
         secrets={private_key_secret},
     )
@@ -97,6 +98,8 @@ def test_endpoint_with_tls_enabled(context, base_state, certificates, ca):
     # WHEN we process any event
     with context(context.on.relation_changed(certificates), base_state) as mgr:
         charm: ParcaOperatorCharm = mgr.charm
+        state_out = mgr.run()
+        container = state_out.get_container("parca")
         # THEN we have TLS enabled
         assert charm._tls_ready
         assert charm._scheme == "https"
@@ -104,6 +107,7 @@ def test_endpoint_with_tls_enabled(context, base_state, certificates, ca):
         scrape_config = charm._self_profiling_scrape_config
         assert "scheme" in scrape_config and scrape_config["scheme"] == "https"
         assert "tls_config" in scrape_config and scrape_config["tls_config"]["ca"] == ca.raw
+        assert "--otlp-insecure=false" in container.plan.services["parca"].command
 
 
 def test_endpoint_with_tls_disabled(


### PR DESCRIPTION
## Issue
Fixes #405 



## Testing Instructions
1. Deploy this bundle
```
bundle: kubernetes
applications:
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 143
    base: ubuntu@20.04/stable
    resources:
      grafana-image: 71
      litestream-image: 46
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  minio:
    charm: minio
    channel: ckf-1.9/edge
    revision: 419
    base: ubuntu@20.04/stable
    resources:
      oci-image: 545
    scale: 1
    options:
      access-key: accesskey
      secret-key: mysoverysecretkey
    constraints: arch=amd64
    storage:
      minio-data: kubernetes,1,10240M
    trust: true
  parca-k8s:
    charm: local:parca-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      profiles: kubernetes,1,1024M
  s3-integrator:
    charm: s3-integrator
    channel: latest/edge
    revision: 139
    base: ubuntu@22.04/stable
    scale: 1
    options:
      bucket: tempo
      endpoint: minio-0.minio-endpoints.test.svc.cluster.local:9000
    constraints: arch=amd64
    trust: true
  ssc:
    charm: self-signed-certificates
    channel: latest/edge
    revision: 266
    base: ubuntu@22.04/stable
    scale: 1
    constraints: arch=amd64
  tempo:
    charm: tempo-coordinator-k8s
    channel: latest/edge
    revision: 71
    base: ubuntu@22.04/stable
    resources:
      nginx-image: 6
      nginx-prometheus-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  worker:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 52
    base: ubuntu@22.04/stable
    resources:
      tempo-image: 5
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
relations:
- - tempo:s3
  - s3-integrator:s3-credentials
- - tempo:tempo-cluster
  - worker:tempo-cluster
- - parca-k8s:grafana-source
  - grafana:grafana-source
- - parca-k8s:workload-tracing
  - tempo:tracing
- - tempo:grafana-source
  - grafana:grafana-source
- - ssc:certificates
  - tempo:certificates
- - ssc:certificates
  - parca-k8s:certificates
- - ssc:certificates
  - grafana:certificates
```
2. In Grafana web UI, run a Parca query on the parca ds
3. check Tempo for traces from `parca`